### PR TITLE
Add stepwise AI client configuration CLI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# vibe-syncer
+# ai-client-configure
+
+`ai-client-configure` is a lightweight command line utility that helps teams create,
+validate, and inspect configuration files for AI chat clients. The tool embraces a
+step-by-step workflow documented in `docs/PROJECT_PLAN.md` so contributors can follow
+a predictable process when extending the project.
+
+## Features
+
+- Scaffold a default configuration file with sensible defaults.
+- Validate configuration files against a strict schema.
+- Display configuration details as a summary table or JSON.
+
+## Installation
+
+The project is packaged with a `pyproject.toml` file. You can install it locally in
+editable mode while developing:
+
+```bash
+pip install -e .
+```
+
+Alternatively you can execute the CLI directly without installing:
+
+```bash
+python -m ai_client_configure --help
+```
+
+## Usage
+
+All commands share the `--config` option which defaults to `ai_client_config.json` in
+the current directory.
+
+### Initialize a configuration file
+
+```bash
+ai-client-configure init
+```
+
+Use `--force` to overwrite an existing file.
+
+### Validate a configuration file
+
+```bash
+ai-client-configure validate
+```
+
+### Show a configuration summary
+
+```bash
+ai-client-configure show
+```
+
+Pass `--as-json` to view the raw JSON output.
+
+## Development workflow
+
+1. Review the staged approach documented in `docs/PROJECT_PLAN.md`.
+2. Run the test suite with `pytest` before committing changes.
+3. Update the documentation when adding new CLI commands or configuration options.
+
+## License
+
+MIT

--- a/ai_client_configure/__init__.py
+++ b/ai_client_configure/__init__.py
@@ -1,0 +1,9 @@
+"""Utility helpers for working with AI client configuration files."""
+
+from .config import ClientConfiguration, ConfigError, load_configuration
+
+__all__ = [
+    "ClientConfiguration",
+    "ConfigError",
+    "load_configuration",
+]

--- a/ai_client_configure/__main__.py
+++ b/ai_client_configure/__main__.py
@@ -1,0 +1,5 @@
+"""Module entry point for ``python -m ai_client_configure``."""
+
+from .cli import main
+
+main()

--- a/ai_client_configure/cli.py
+++ b/ai_client_configure/cli.py
@@ -1,0 +1,128 @@
+"""Command line entry point for ai-client-configure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .config import ClientConfiguration, ConfigError, dump_configuration, load_configuration
+
+DEFAULT_CONFIG_PATH = Path("ai_client_config.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ai-client-configure",
+        description="Manage configuration files for AI chat clients.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the configuration file (default: ai_client_config.json)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Create a new configuration file with default values.",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the file if it already exists.",
+    )
+    init_parser.set_defaults(func=handle_init)
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate the configuration file and report any issues.",
+    )
+    validate_parser.set_defaults(func=handle_validate)
+
+    show_parser = subparsers.add_parser(
+        "show",
+        help="Display the configuration in a human readable form.",
+    )
+    show_parser.add_argument(
+        "--as-json",
+        action="store_true",
+        help="Print the configuration as JSON instead of a summary table.",
+    )
+    show_parser.set_defaults(func=handle_show)
+
+    return parser
+
+
+def handle_init(args: argparse.Namespace) -> int:
+    config_path: Path = args.config
+    if config_path.exists() and not args.force:
+        print(
+            f"Configuration file {config_path} already exists. Use --force to overwrite.",
+            file=sys.stderr,
+        )
+        return 1
+
+    default_config = ClientConfiguration(model="gpt-4.1-mini")
+    dump_configuration(default_config, config_path)
+    print(f"Created configuration file at {config_path}")
+    return 0
+
+
+def handle_validate(args: argparse.Namespace) -> int:
+    try:
+        load_configuration(args.config)
+    except ConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Configuration {args.config} is valid.")
+    return 0
+
+
+def _format_summary(config: ClientConfiguration) -> str:
+    rows = [
+        ("Model", config.model),
+        ("Temperature", f"{config.temperature:.2f}"),
+        ("Max tokens", str(config.max_output_tokens)),
+        ("Top-p", f"{config.top_p:.2f}"),
+        ("Endpoint", config.endpoint),
+        ("API key env", config.api_key_env),
+    ]
+    if config.extras:
+        rows.append(("Extras", json.dumps(config.extras, indent=2)))
+
+    label_width = max(len(label) for label, _ in rows)
+    lines = [f"{label:<{label_width}} : {value}" for label, value in rows]
+    return "\n".join(lines)
+
+
+def handle_show(args: argparse.Namespace) -> int:
+    try:
+        config = load_configuration(args.config)
+    except ConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.as_json:
+        print(json.dumps(config.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(_format_summary(config))
+    return 0
+
+
+def dispatch(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+def main(argv: list[str] | None = None) -> None:
+    sys.exit(dispatch(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/ai_client_configure/config.py
+++ b/ai_client_configure/config.py
@@ -1,0 +1,133 @@
+"""Core configuration dataclasses and helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+SUPPORTED_MODELS = {
+    "gpt-4.1-mini",
+    "gpt-4o",
+    "claude-3-sonnet",
+}
+
+
+def _coerce_float(value: Any, name: str) -> float:
+    try:
+        return float(value)
+    except (ValueError, TypeError) as exc:
+        raise ConfigError(f"{name} must be a number, received {value!r}") from exc
+
+
+def _coerce_int(value: Any, name: str) -> int:
+    try:
+        return int(value)
+    except (ValueError, TypeError) as exc:
+        raise ConfigError(f"{name} must be an integer, received {value!r}") from exc
+
+
+class ConfigError(ValueError):
+    """Raised when a configuration file cannot be parsed or validated."""
+
+
+@dataclass(slots=True)
+class ClientConfiguration:
+    """Represents configuration values for an AI client."""
+
+    model: str
+    temperature: float = 0.7
+    max_output_tokens: int = 1024
+    top_p: float = 0.95
+    endpoint: str = "https://api.openai.com/v1/chat/completions"
+    api_key_env: str = "OPENAI_API_KEY"
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the configuration to a dictionary suitable for JSON."""
+
+        payload = {
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_output_tokens": self.max_output_tokens,
+            "top_p": self.top_p,
+            "endpoint": self.endpoint,
+            "api_key_env": self.api_key_env,
+        }
+        payload.update(self.extras)
+        return payload
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "ClientConfiguration":
+        """Construct a configuration from a dictionary."""
+
+        if "model" not in raw:
+            raise ConfigError("`model` is required in the configuration file.")
+        model = str(raw["model"]).strip()
+        if not model:
+            raise ConfigError("`model` cannot be empty.")
+        if SUPPORTED_MODELS and model not in SUPPORTED_MODELS:
+            raise ConfigError(
+                f"`model` must be one of {sorted(SUPPORTED_MODELS)}, received {model!r}."
+            )
+
+        temperature = _coerce_float(raw.get("temperature", 0.7), "temperature")
+        if not 0 <= temperature <= 2:
+            raise ConfigError("`temperature` must be between 0 and 2.")
+
+        max_output_tokens = _coerce_int(raw.get("max_output_tokens", 1024), "max_output_tokens")
+        if max_output_tokens <= 0:
+            raise ConfigError("`max_output_tokens` must be positive.")
+
+        top_p = _coerce_float(raw.get("top_p", 0.95), "top_p")
+        if not 0 < top_p <= 1:
+            raise ConfigError("`top_p` must be between 0 (exclusive) and 1 (inclusive).")
+
+        endpoint = str(raw.get("endpoint", "https://api.openai.com/v1/chat/completions"))
+        if not endpoint:
+            raise ConfigError("`endpoint` cannot be empty.")
+
+        api_key_env = str(raw.get("api_key_env", "OPENAI_API_KEY"))
+        if not api_key_env:
+            raise ConfigError("`api_key_env` cannot be empty.")
+
+        extras: Dict[str, Any] = {
+            key: value
+            for key, value in raw.items()
+            if key
+            not in {"model", "temperature", "max_output_tokens", "top_p", "endpoint", "api_key_env"}
+        }
+
+        return cls(
+            model=model,
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+            top_p=top_p,
+            endpoint=endpoint,
+            api_key_env=api_key_env,
+            extras=extras,
+        )
+
+
+def load_configuration(path: str | Path) -> ClientConfiguration:
+    """Load a configuration file from disk."""
+
+    target = Path(path)
+    if not target.exists():
+        raise ConfigError(f"Configuration file {target} does not exist.")
+    try:
+        data = json.loads(target.read_text())
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Configuration file {target} is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ConfigError("Configuration file must contain a JSON object.")
+    return ClientConfiguration.from_dict(data)
+
+
+def dump_configuration(config: ClientConfiguration, path: str | Path) -> None:
+    """Write a configuration to disk as nicely formatted JSON."""
+
+    target = Path(path)
+    target.write_text(json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n")

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,35 @@
+# Project Plan: AI Client Configure
+
+This document describes the staged approach used to build the **ai-client-configure**
+command line utility. Each stage can be executed independently and verified before
+moving to the next step.
+
+## Stage 1 – Establish the foundation
+
+- Create the Python package layout with `ai_client_configure/`.
+- Implement the core configuration dataclass and validation helpers.
+- Provide a module entry point for use with `python -m ai_client_configure`.
+
+## Stage 2 – Command line interface
+
+- Add an ergonomic CLI built on top of `argparse`.
+- Support the following subcommands:
+  - `init`: scaffold a default configuration file.
+  - `validate`: check a configuration file for schema violations.
+  - `show`: display a configuration summary or raw JSON.
+- Ensure that all subcommands share the `--config` option so the target file is easy
+  to override.
+
+## Stage 3 – Documentation and packaging metadata
+
+- Expand the README with usage instructions and examples.
+- Add a `pyproject.toml` describing the project metadata and CLI entry point.
+- Document the staged approach in this file so contributors know how to extend the
+  tool.
+
+## Stage 4 – Quality gates
+
+- Provide a small pytest suite that exercises configuration validation logic.
+- Encourage running `pytest` locally before committing changes.
+- Future work: integrate linters such as Ruff or mypy if type checking becomes
+  necessary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ai-client-configure"
+version = "0.1.0"
+description = "Command-line utility for managing AI client configuration files"
+authors = [
+  { name = "AI Assistant" }
+]
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+dependencies = []
+
+[project.scripts]
+ai-client-configure = "ai_client_configure.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-q"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,53 @@
+"""Tests for ai_client_configure.config."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ai_client_configure.config import (
+    ClientConfiguration,
+    ConfigError,
+    dump_configuration,
+    load_configuration,
+)
+
+
+@pytest.fixture()
+def tmp_config_path(tmp_path: Path) -> Path:
+    return tmp_path / "config.json"
+
+
+def test_dump_and_load_round_trip(tmp_config_path: Path) -> None:
+    config = ClientConfiguration(model="gpt-4.1-mini", temperature=0.5, max_output_tokens=256)
+    dump_configuration(config, tmp_config_path)
+
+    loaded = load_configuration(tmp_config_path)
+    assert loaded.model == "gpt-4.1-mini"
+    assert loaded.temperature == pytest.approx(0.5)
+    assert loaded.max_output_tokens == 256
+
+
+def test_load_configuration_requires_valid_json(tmp_config_path: Path) -> None:
+    tmp_config_path.write_text("not json")
+
+    with pytest.raises(ConfigError):
+        load_configuration(tmp_config_path)
+
+
+def test_validation_rejects_unknown_model() -> None:
+    with pytest.raises(ConfigError):
+        ClientConfiguration.from_dict({"model": "unknown"})
+
+
+def test_validation_enforces_temperature_range() -> None:
+    with pytest.raises(ConfigError):
+        ClientConfiguration.from_dict({"model": "gpt-4.1-mini", "temperature": 10})
+
+
+def test_show_includes_extras(tmp_config_path: Path) -> None:
+    config = ClientConfiguration(model="gpt-4.1-mini", extras={"timeout": 30})
+    dump_configuration(config, tmp_config_path)
+
+    data = json.loads(tmp_config_path.read_text())
+    assert data["timeout"] == 30


### PR DESCRIPTION
## Summary
- scaffold the `ai-client-configure` package with configuration validation and CLI commands
- document the staged workflow in `docs/PROJECT_PLAN.md` and expand the README with usage guidance
- add a pytest suite that exercises configuration parsing and validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8b1786ba88321b8391f2c605cd81e