### PR TITLE
Add Ruff linting stage and developer workflow updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ editable mode while developing:
 pip install -e .
 ```
 
+Install the optional development dependencies to run linters locally:
+
+```bash
+pip install -e .[dev]
+```
+
 Alternatively you can execute the CLI directly without installing:
 
 ```bash
@@ -56,7 +62,13 @@ Pass `--as-json` to view the raw JSON output.
 ## Development workflow
 
 1. Review the staged approach documented in `docs/PROJECT_PLAN.md`.
-2. Run the test suite with `pytest` before committing changes.
+2. Run static analysis and the test suite before committing changes:
+
+   ```bash
+   ruff check .
+   pytest
+   ```
+
 3. Update the documentation when adding new CLI commands or configuration options.
 
 ## License

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -33,3 +33,9 @@ moving to the next step.
 - Encourage running `pytest` locally before committing changes.
 - Future work: integrate linters such as Ruff or mypy if type checking becomes
   necessary.
+
+## Stage 5 – Static analysis tooling
+
+- Add a Ruff configuration to enforce consistent imports and style checks.
+- Provide an optional `dev` dependency group so contributors can install linting tools.
+- Document the expectation that `ruff check .` is run alongside the test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,29 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = []
 
+[project.optional-dependencies]
+dev = [
+  "ruff>=0.4,<0.5",
+]
+
 [project.scripts]
 ai-client-configure = "ai_client_configure.cli:main"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
 addopts = "-q"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+  "E",  # pycodestyle errors
+  "F",  # pyflakes
+  "I",  # isort
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Summary
- configure Ruff linting in pyproject.toml and expose a development dependency group
- document the new linting workflow in the README and extend the staged project plan
- add a .gitignore to filter build and cache artifacts from version control

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d8b99cc240832189d1eb9aa9a964fa